### PR TITLE
feat(armory-io): added functionality to wait for the deployment to complete; cleanup of the action's output parameters

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -29,10 +29,18 @@ inputs:
     description: 'Location of the Armory Cloud API which will handle your deployment'
     default: 'api.cloud.armory.io'
     required: false
+  waitForDeployment:
+    description: 'Boolean flag (true|false) determining if the action should wait for the deployment to complete. "false" by default.'
+    default: 'false'
+    required: false
 
 outputs:
-  deployment-link:
-    description: 'HTTP link and deployment id used to see the status of your deployment'
+  DEPLOYMENT_ID:
+    description: 'Unique deployment identifier - can be used to query the status of the deployment in cloud-console'
+  LINK:
+    description: 'Link to the cloud-console, where you can check the state of the workflow and advance it to the next stages'
+  RUN_RESULT:
+    description: "If deployment was triggered with 'waitForDeployment=true' flag, this variable will contain final status of the deployment - one of [SUCCEEDED, CANCELLED, FAILED, UNKNOWN (error)]"
 
 runs:
   using: 'docker'
@@ -48,3 +56,4 @@ runs:
     - ${{ inputs.path-to-file }}
     - ${{ inputs.applicationName }}
     - ${{ inputs.addContext }}
+    - ${{ inputs.waitForDeployment }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,10 @@ if [ -n "${3}" ]; then
    EXTRA_ARGS="${EXTRA_ARGS} --add-context=${3}"
 fi
 
+if [ "${4,,}" = "true" ]; then
+  EXTRA_ARGS="${EXTRA_ARGS} --watch"
+fi
+
 armory version
 armory deploy start ${EXTRA_ARGS} --file "${1}"
 


### PR DESCRIPTION
With latest version of the CLI, one can trigger deployment in sync mode (--watch or -w) - action will block until deployment completed.

Added 3 output parameters to the action:
- LINK - cloud console url to monitor current deployment
- PIPELINE_ID - unique identifier of the current pipeline's execution
- RUN_RESULT - filled only when action runs in sync mode - will contain final status of the deployment workflow